### PR TITLE
No Styles Option

### DIFF
--- a/public/connector.js
+++ b/public/connector.js
@@ -12,7 +12,7 @@ window.TrelloPowerUp.initialize({
                         return t.popup({
                             title: "Select Fields",
                             url: "options.html",
-                            height: 200
+                            height: 250
                         })
                     },
                     condition: 'always'

--- a/public/connector.js
+++ b/public/connector.js
@@ -12,7 +12,7 @@ window.TrelloPowerUp.initialize({
                         return t.popup({
                             title: "Select Fields",
                             url: "options.html",
-                            height: 250
+                            height: 240
                         })
                     },
                     condition: 'always'

--- a/public/js/generate.js
+++ b/public/js/generate.js
@@ -80,9 +80,17 @@ function addCardDetailsToOutput(cardInfo) {
 
     // Add labels
     if (cardInfo.labels.length > 0) {
-        cardInfo.labels.forEach((label) => {
-            markdownCard += labelTemplate.replace(/ENTER_COLOR_HERE/g, colors[label.color]).replace(/ENTER_LABEL_NAME_HERE/g, label.name) + ' ';
-        });
+        if (document.getElementById('addStyle').checked === false) {
+            cardInfo.labels.forEach((label) => {
+                markdownCard += labelTemplate.replace(/ENTER_COLOR_HERE/g, colors[label.color]).replace(/ENTER_LABEL_NAME_HERE/g, label.name) + ' ';
+            });
+        }
+        else {
+            cardInfo.labels.forEach((label) => {
+                markdownCard += label.name + ' (' + label.color + '), ';
+            });
+            markdownCard = markdownCard.slice(0, -2);
+        }
     }
 
     // Add due date
@@ -95,10 +103,17 @@ function addCardDetailsToOutput(cardInfo) {
 function addMembersToOutput(memberInfo) {
     let markdownMembers = '';
     if (memberInfo.length > 0) {
-        markdownMembers += '## Members of Card: \n'
-        memberInfo.forEach((member) => {
-            markdownMembers += memberTemplate.replace(/ENTER_MEMBER_HERE/g, member.initials) + '  ' + member.fullName + '\n';
-        })
+        markdownMembers += '## Members of Card: \n';
+        if (document.getElementById('addStyle').checked === false) {
+            memberInfo.forEach((member) => {
+                markdownMembers += memberTemplate.replace(/ENTER_MEMBER_HERE/g, member.initials) + '  ' + member.fullName + '\n';
+            });
+        }
+        else {
+            memberInfo.forEach((member) => {
+                markdownMembers += '- ' +  member.fullName + '\n'
+            });
+        }
     }
 
     markdownMemberDetails += markdownMembers;

--- a/public/options.html
+++ b/public/options.html
@@ -44,7 +44,7 @@
   <hr>
   <div class="form-check" style="margin-top: 4px">
     <input type="checkbox" class="form-check-input" id="addStyle">
-    <label class="form-check-label" for="addStyle"><b>No Style?</b></label>
+    <label class="form-check-label" for="addStyle"><b>Remove Styling?</b></label>
   </div>
   <br>
   <button type="submit" class="btn btn-success form-control">Save</button>

--- a/public/options.html
+++ b/public/options.html
@@ -22,7 +22,7 @@
       <label class="form-check-label" for="showBoard">Name of Board</label>
     </div>
 
-    <div class="form-check" style="margin-top: 4px; margin-left: 36px">
+    <div class="form-check" style="margin-top: 4px; margin-left: 24px">
       <input type="checkbox" class="form-check-input" id="showList">
       <label class="form-check-label" for="showList">Name of List</label>
     </div>
@@ -34,13 +34,12 @@
       <label class="form-check-label" for="showChecklist">Checklist(s)</label>
     </div>
 
-    <div class="form-check" style="margin-top: 4px; margin-left: 61px">
+    <div class="form-check" style="margin-top: 4px; margin-left: 48px">
       <input type="checkbox" class="form-check-input" id="showMembers">
       <label class="form-check-label" for="showMembers">Members of Card</label>
     </div>
   </div>
 
-  <br>
   <hr>
   <div class="form-check" style="margin-top: 4px">
     <input type="checkbox" class="form-check-input" id="addStyle">

--- a/public/options.html
+++ b/public/options.html
@@ -1,45 +1,54 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <title>Export Card to Markdown</title>
+<head>
+  <meta charset="UTF-8">
+  <title>Export Card to Markdown</title>
 
-    <script src="https://trello.com/power-ups/power-up.min.js"></script>
-    <script src="https://p.trellocdn.com/power-up.min.js" crossorigin="anonymous"></script>
+  <script src="https://trello.com/power-ups/power-up.min.js"></script>
+  <script src="https://p.trellocdn.com/power-up.min.js" crossorigin="anonymous"></script>
 
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
-  </head>
-  <body>
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+</head>
+<body>
+<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
 
-    <p style="font-size: 14px"><b>Include:</b></p>
+<b style="font-size: 14px">Include:</b>
+<form id="fields" style="font-size: 14px">
+  <div class="form-row">
+    <div class="form-check" style="margin-top: 4px; margin-left: 6px">
+      <input type="checkbox" class="form-check-input" id="showBoard">
+      <label class="form-check-label" for="showBoard">Name of Board</label>
+    </div>
 
-    <form id="fields" style="font-size: 14px">
-      <div class="form-check" style="margin-top: 4px">
-        <input type="checkbox" class="form-check-input" id="showBoard">
-        <label class="form-check-label" for="showBoard">Name of Board</label>
-      </div>
+    <div class="form-check" style="margin-top: 4px; margin-left: 36px">
+      <input type="checkbox" class="form-check-input" id="showList">
+      <label class="form-check-label" for="showList">Name of List</label>
+    </div>
+  </div>
 
-      <div class="form-check" style="margin-top: 4px">
-        <input type="checkbox" class="form-check-input" id="showList">
-        <label class="form-check-label" for="showList">Name of List</label>
-      </div>
+  <div class="form-row">
+    <div class="form-check" style="margin-top: 4px; margin-left: 6px">
+      <input type="checkbox" class="form-check-input" id="showChecklist">
+      <label class="form-check-label" for="showChecklist">Checklist(s)</label>
+    </div>
 
-      <div class="form-check" style="margin-top: 4px">
-        <input type="checkbox" class="form-check-input" id="showChecklist">
-        <label class="form-check-label" for="showChecklist">Checklist(s)</label>
-      </div>
+    <div class="form-check" style="margin-top: 4px; margin-left: 61px">
+      <input type="checkbox" class="form-check-input" id="showMembers">
+      <label class="form-check-label" for="showMembers">Members of Card</label>
+    </div>
+  </div>
 
-      <div class="form-check" style="margin-top: 4px">
-        <input type="checkbox" class="form-check-input" id="showMembers">
-        <label class="form-check-label" for="showMembers">Members of Card</label>
-      </div>
-
-      <br>
-      <button type="submit" class="btn btn-success">Save</button>
-    </form>
-    <script src="./js/generate.js"></script>
-  </body>
+  <br>
+  <hr>
+  <div class="form-check" style="margin-top: 4px">
+    <input type="checkbox" class="form-check-input" id="addStyle">
+    <label class="form-check-label" for="addStyle"><b>No Style?</b></label>
+  </div>
+  <br>
+  <button type="submit" class="btn btn-success form-control">Save</button>
+</form>
+<script src="./js/generate.js"></script>
+</body>
 </html>

--- a/public/options.html
+++ b/public/options.html
@@ -16,28 +16,24 @@
 
 <b style="font-size: 14px">Include:</b>
 <form id="fields" style="font-size: 14px">
-  <div class="form-row">
-    <div class="form-check" style="margin-top: 4px; margin-left: 6px">
-      <input type="checkbox" class="form-check-input" id="showBoard">
-      <label class="form-check-label" for="showBoard">Name of Board</label>
-    </div>
-
-    <div class="form-check" style="margin-top: 4px; margin-left: 18px">
-      <input type="checkbox" class="form-check-input" id="showList">
-      <label class="form-check-label" for="showList">Name of List</label>
-    </div>
+  <div class="form-check" style="margin-top: 4px">
+    <input type="checkbox" class="form-check-input" id="showBoard">
+    <label class="form-check-label" for="showBoard">Name of Board</label>
   </div>
 
-  <div class="form-row">
-    <div class="form-check" style="margin-top: 4px; margin-left: 6px">
-      <input type="checkbox" class="form-check-input" id="showChecklist">
-      <label class="form-check-label" for="showChecklist">Checklist(s)</label>
-    </div>
+  <div class="form-check" style="margin-top: 4px">
+    <input type="checkbox" class="form-check-input" id="showList">
+    <label class="form-check-label" for="showList">Name of List</label>
+  </div>
 
-    <div class="form-check" style="margin-top: 4px; margin-left: 42px">
-      <input type="checkbox" class="form-check-input" id="showMembers">
-      <label class="form-check-label" for="showMembers">Members of Card</label>
-    </div>
+  <div class="form-check" style="margin-top: 4px">
+    <input type="checkbox" class="form-check-input" id="showChecklist">
+    <label class="form-check-label" for="showChecklist">Checklist(s)</label>
+  </div>
+
+  <div class="form-check" style="margin-top: 4px">
+    <input type="checkbox" class="form-check-input" id="showMembers">
+    <label class="form-check-label" for="showMembers">Members of Card</label>
   </div>
 
   <hr>
@@ -52,6 +48,7 @@
       </a>
     </label>
   </div>
+  <br>
   <button type="submit" class="btn btn-success">Save</button>
 </form>
 <script src="./js/generate.js"></script>

--- a/public/options.html
+++ b/public/options.html
@@ -41,7 +41,7 @@
     <input type="checkbox" class="form-check-input" id="addStyle">
     <label class="form-check-label" for="addStyle">
       <b>Remove Styling?&#160</b>
-      <a href="#" data-toggle="tooltip" data-placement="bottom" data-html="true" title="<p>By default, the markdown will contain HTML code with CSS. If you do not want this, then select this option</p>" style="cursor: default">
+      <a href="#" data-toggle="tooltip" data-placement="bottom" data-html="true" title="By default, the markdown will contain HTML code with CSS. If you do not want this, then select this option" style="cursor: default">
         <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-patch-question-fll" fill="currentColor" xmlns="http://www.w3.org/2000/svg" style="margin-bottom: 4px" data-toggle="tooltip">
           <path fill-rule="evenodd" d="M5.933.87a2.89 2.89 0 0 1 4.134 0l.622.638.89-.011a2.89 2.89 0 0 1 2.924 2.924l-.01.89.636.622a2.89 2.89 0 0 1 0 4.134l-.637.622.011.89a2.89 2.89 0 0 1-2.924 2.924l-.89-.01-.622.636a2.89 2.89 0 0 1-4.134 0l-.622-.637-.89.011a2.89 2.89 0 0 1-2.924-2.924l.01-.89-.636-.622a2.89 2.89 0 0 1 0-4.134l.637-.622-.011-.89a2.89 2.89 0 0 1 2.924-2.924l.89.01.622-.636zM7.002 11a1 1 0 1 1 2 0 1 1 0 0 1-2 0zm1.602-2.027c-.05.386-.218.627-.554.627-.377 0-.585-.317-.585-.745v-.11c0-.727.307-1.208.926-1.641.614-.44.822-.762.822-1.325 0-.638-.42-1.084-1.03-1.084-.55 0-.916.323-1.074.914-.109.364-.292.51-.564.51C6.203 6.12 6 5.873 6 5.48c0-.251.045-.468.139-.69.307-.798 1.079-1.29 2.099-1.29 1.341 0 2.262.902 2.262 2.227 0 .896-.376 1.511-1.05 1.986-.648.445-.806.726-.846 1.26z"/>
         </svg>

--- a/public/options.html
+++ b/public/options.html
@@ -49,7 +49,7 @@
     </label>
   </div>
   <br>
-  <button type="submit" class="btn btn-success">Save</button>
+  <button type="submit" class="btn btn-success form-control">Save</button>
 </form>
 <script src="./js/generate.js"></script>
 </body>

--- a/public/options.html
+++ b/public/options.html
@@ -22,7 +22,7 @@
       <label class="form-check-label" for="showBoard">Name of Board</label>
     </div>
 
-    <div class="form-check" style="margin-top: 4px; margin-left: 24px">
+    <div class="form-check" style="margin-top: 4px; margin-left: 18px">
       <input type="checkbox" class="form-check-input" id="showList">
       <label class="form-check-label" for="showList">Name of List</label>
     </div>
@@ -34,7 +34,7 @@
       <label class="form-check-label" for="showChecklist">Checklist(s)</label>
     </div>
 
-    <div class="form-check" style="margin-top: 4px; margin-left: 48px">
+    <div class="form-check" style="margin-top: 4px; margin-left: 42px">
       <input type="checkbox" class="form-check-input" id="showMembers">
       <label class="form-check-label" for="showMembers">Members of Card</label>
     </div>
@@ -52,7 +52,6 @@
       </a>
     </label>
   </div>
-  <br>
   <button type="submit" class="btn btn-success">Save</button>
 </form>
 <script src="./js/generate.js"></script>

--- a/public/options.html
+++ b/public/options.html
@@ -43,10 +43,17 @@
   <hr>
   <div class="form-check" style="margin-top: 4px">
     <input type="checkbox" class="form-check-input" id="addStyle">
-    <label class="form-check-label" for="addStyle"><b>Remove Styling?</b></label>
+    <label class="form-check-label" for="addStyle">
+      <b>Remove Styling?&#160</b>
+      <a href="#" data-toggle="tooltip" data-placement="bottom" data-html="true" title="<p>By default, the markdown will contain HTML code with CSS. If you do not want this, then select this option</p>" style="cursor: default">
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-patch-question-fll" fill="currentColor" xmlns="http://www.w3.org/2000/svg" style="margin-bottom: 4px" data-toggle="tooltip">
+          <path fill-rule="evenodd" d="M5.933.87a2.89 2.89 0 0 1 4.134 0l.622.638.89-.011a2.89 2.89 0 0 1 2.924 2.924l-.01.89.636.622a2.89 2.89 0 0 1 0 4.134l-.637.622.011.89a2.89 2.89 0 0 1-2.924 2.924l-.89-.01-.622.636a2.89 2.89 0 0 1-4.134 0l-.622-.637-.89.011a2.89 2.89 0 0 1-2.924-2.924l.01-.89-.636-.622a2.89 2.89 0 0 1 0-4.134l.637-.622-.011-.89a2.89 2.89 0 0 1 2.924-2.924l.89.01.622-.636zM7.002 11a1 1 0 1 1 2 0 1 1 0 0 1-2 0zm1.602-2.027c-.05.386-.218.627-.554.627-.377 0-.585-.317-.585-.745v-.11c0-.727.307-1.208.926-1.641.614-.44.822-.762.822-1.325 0-.638-.42-1.084-1.03-1.084-.55 0-.916.323-1.074.914-.109.364-.292.51-.564.51C6.203 6.12 6 5.873 6 5.48c0-.251.045-.468.139-.69.307-.798 1.079-1.29 2.099-1.29 1.341 0 2.262.902 2.262 2.227 0 .896-.376 1.511-1.05 1.986-.648.445-.806.726-.846 1.26z"/>
+        </svg>
+      </a>
+    </label>
   </div>
   <br>
-  <button type="submit" class="btn btn-success form-control">Save</button>
+  <button type="submit" class="btn btn-success">Save</button>
 </form>
 <script src="./js/generate.js"></script>
 </body>


### PR DESCRIPTION
This option will allow users to export a card to pure markdown; without any HTML or CSS directly embedded into the markdown document. It will benefit those whose markdown editor does not parse HTML tags and CSS selectors.

A tooltip has been added to explain this option to users.

![image](https://user-images.githubusercontent.com/18406063/89041996-404fce00-d314-11ea-9f51-5de20b0733be.png)
